### PR TITLE
[yunbok] 데이터 검색 api 구현 

### DIFF
--- a/src/main/java/com/yunbok/searchapi/SearchApiApplication.java
+++ b/src/main/java/com/yunbok/searchapi/SearchApiApplication.java
@@ -2,7 +2,6 @@ package com.yunbok.searchapi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 public class SearchApiApplication {

--- a/src/main/java/com/yunbok/searchapi/v1/authentication/service/AuthenticationService.java
+++ b/src/main/java/com/yunbok/searchapi/v1/authentication/service/AuthenticationService.java
@@ -9,11 +9,6 @@ import com.yunbok.searchapi.v1.authentication.exception.ApiAuthenticationExcepti
 import com.yunbok.searchapi.v1.authentication.repository.ApiKeyRepository;
 import com.yunbok.searchapi.v1.authentication.util.ApiKeyGenerator;
 import com.yunbok.searchapi.v1.authentication.util.JwtTokenProvider;
-import com.yunbok.searchapi.v1.authentication.dto.request.ApiKeyRequest;
-import com.yunbok.searchapi.v1.authentication.dto.response.ApiKeyResponse;
-import com.yunbok.searchapi.v1.authentication.entity.ApiKey;
-import com.yunbok.searchapi.v1.authentication.repository.ApiKeyRepository;
-import com.yunbok.searchapi.v1.authentication.util.ApiKeyUtil;
 import com.yunbok.searchapi.v1.common.define.ResponseCode;
 import com.yunbok.searchapi.v1.authentication.entity.User;
 import com.yunbok.searchapi.v1.common.exception.ApiClientException;

--- a/src/main/java/com/yunbok/searchapi/v1/authentication/util/JwtTokenProvider.java
+++ b/src/main/java/com/yunbok/searchapi/v1/authentication/util/JwtTokenProvider.java
@@ -1,6 +1,11 @@
 package com.yunbok.searchapi.v1.authentication.util;
 
 import com.yunbok.searchapi.v1.authentication.dto.response.AccessTokenResponse;
+import com.yunbok.searchapi.v1.authentication.exception.AuthenticationException;
+import com.yunbok.searchapi.v1.common.define.ResponseCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
@@ -20,6 +25,21 @@ public class JwtTokenProvider {
 
     public AccessTokenResponse generateJwtToken(String account) {
         return doGenerateToken(account, secretKey, expirationTime);
+    }
+
+    public void validateToken(String token) throws AuthenticationException {
+        try {
+            Jws<Claims> claims = Jwts.parserBuilder()
+                    .setSigningKey(getKey(secretKey))
+                    .build()
+                    .parseClaimsJws(token);
+
+            if (claims.getBody().getExpiration().before(new Date())) {
+                throw new JwtException("invalid access token");
+            }
+        } catch (JwtException e) {
+            throw new AuthenticationException("invalid access token", ResponseCode.INVALID_REQUEST);
+        }
     }
 
     private AccessTokenResponse doGenerateToken(String subject, String secretKey, long expirationTime) {

--- a/src/main/java/com/yunbok/searchapi/v1/common/config/WebConfig.java
+++ b/src/main/java/com/yunbok/searchapi/v1/common/config/WebConfig.java
@@ -1,0 +1,28 @@
+package com.yunbok.searchapi.v1.common.config;
+
+import com.yunbok.searchapi.v1.authentication.util.JwtTokenProvider;
+import com.yunbok.searchapi.v1.common.interceptor.AccessTokenInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Bean
+    public AccessTokenInterceptor accessTokenInterceptor() {
+        return new AccessTokenInterceptor(jwtTokenProvider);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(accessTokenInterceptor())
+                .addPathPatterns("/v1/search/**")
+                .excludePathPatterns("/v1/authentication/**");
+    }
+}

--- a/src/main/java/com/yunbok/searchapi/v1/common/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/yunbok/searchapi/v1/common/exception/ApiExceptionHandler.java
@@ -33,10 +33,10 @@ public class ApiExceptionHandler {
     }
 
     @ExceptionHandler(AuthenticationException.class)
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
     public ResponseEntity<ErrorResponse> handleAuthenticationException(AuthenticationException e) {
-        return ResponseEntity.internalServerError()
-                .body(ErrorResponse.responseOf(ResponseCode.SERVER_ERROR, e.getMessage()));
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ErrorResponse.responseOf(ResponseCode.UNAUTHORIZED, e.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/com/yunbok/searchapi/v1/common/interceptor/AccessTokenInterceptor.java
+++ b/src/main/java/com/yunbok/searchapi/v1/common/interceptor/AccessTokenInterceptor.java
@@ -1,0 +1,33 @@
+package com.yunbok.searchapi.v1.common.interceptor;
+
+import com.yunbok.searchapi.v1.authentication.exception.AuthenticationException;
+import com.yunbok.searchapi.v1.authentication.util.JwtTokenProvider;
+import com.yunbok.searchapi.v1.common.define.ResponseCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@RequiredArgsConstructor
+public class AccessTokenInterceptor implements HandlerInterceptor {
+
+    private static final String AUTH_HEADER = "Authorization";
+    private static final String TOKEN_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+            throws Exception {
+        // Authorization 헤더에서 JWT 토큰 추출
+        String authHeader = request.getHeader(AUTH_HEADER);
+        if (authHeader == null || !authHeader.startsWith(TOKEN_PREFIX)) {
+            throw new AuthenticationException("invalid access token", ResponseCode.INVALID_REQUEST);
+        }
+
+        String token = authHeader.replace(TOKEN_PREFIX, "");
+        jwtTokenProvider.validateToken(token);
+
+        return true;
+    }
+}

--- a/src/main/java/com/yunbok/searchapi/v1/search/controller/SearchController.java
+++ b/src/main/java/com/yunbok/searchapi/v1/search/controller/SearchController.java
@@ -1,0 +1,27 @@
+package com.yunbok.searchapi.v1.search.controller;
+
+import com.yunbok.searchapi.v1.search.dto.BookResponse;
+import com.yunbok.searchapi.v1.search.dto.SearchRequest;
+import com.yunbok.searchapi.v1.search.service.SearchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("/v1/search")
+@RestController
+public class SearchController {
+
+    private final SearchService searchService;
+
+    @GetMapping
+    public ResponseEntity<?> searchWeb(SearchRequest searchRequest) {
+        List<BookResponse> result = searchService.search(searchRequest);
+
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/com/yunbok/searchapi/v1/search/dto/BookResponse.java
+++ b/src/main/java/com/yunbok/searchapi/v1/search/dto/BookResponse.java
@@ -1,0 +1,12 @@
+package com.yunbok.searchapi.v1.search.dto;
+
+public record BookResponse(
+        String library,
+        String location,
+        String registrationNumber,
+        String title,
+        String author,
+        String publisher,
+        String publicationYear,
+        String callNumber
+) {}

--- a/src/main/java/com/yunbok/searchapi/v1/search/dto/SearchRequest.java
+++ b/src/main/java/com/yunbok/searchapi/v1/search/dto/SearchRequest.java
@@ -1,0 +1,9 @@
+package com.yunbok.searchapi.v1.search.dto;
+
+public record SearchRequest(
+        String query,
+        String sort,
+        int page,
+        int pageSize
+) {}
+

--- a/src/main/java/com/yunbok/searchapi/v1/search/entity/Book.java
+++ b/src/main/java/com/yunbok/searchapi/v1/search/entity/Book.java
@@ -1,0 +1,42 @@
+package com.yunbok.searchapi.v1.search.entity;
+
+
+import com.yunbok.searchapi.v1.common.entity.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Book extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String library;
+    private String location;
+    private String registrationNumber;
+    private String title;
+    private String author;
+    private String publisher;
+    private String publicationYear;
+    private String callNumber;
+
+    public Book(String library, String location, String registrationNumber, String title,
+                String author, String publisher, String publicationYear, String callNumber) {
+        this.library = library;
+        this.location = location;
+        this.registrationNumber = registrationNumber;
+        this.title = title;
+        this.author = author;
+        this.publisher = publisher;
+        this.publicationYear = publicationYear;
+        this.callNumber = callNumber;
+    }
+}

--- a/src/main/java/com/yunbok/searchapi/v1/search/repository/BookRepository.java
+++ b/src/main/java/com/yunbok/searchapi/v1/search/repository/BookRepository.java
@@ -1,0 +1,11 @@
+package com.yunbok.searchapi.v1.search.repository;
+
+import com.yunbok.searchapi.v1.search.entity.Book;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface BookRepository extends JpaRepository<Book, Long> {
+
+    List<Book> findByTitleContainingIgnoreCase(String title);
+}

--- a/src/main/java/com/yunbok/searchapi/v1/search/service/SearchService.java
+++ b/src/main/java/com/yunbok/searchapi/v1/search/service/SearchService.java
@@ -1,0 +1,31 @@
+package com.yunbok.searchapi.v1.search.service;
+
+import com.yunbok.searchapi.v1.search.dto.BookResponse;
+import com.yunbok.searchapi.v1.search.dto.SearchRequest;
+import com.yunbok.searchapi.v1.search.entity.Book;
+import com.yunbok.searchapi.v1.search.repository.BookRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class SearchService {
+
+    private final BookRepository bookRepository;
+
+    public List<BookResponse> search(SearchRequest searchRequest) {
+        return bookRepository.findByTitleContainingIgnoreCase(searchRequest.query()).stream()
+                .map(this::convertBookToResponse)
+                .collect(Collectors.toList());
+    }
+
+    private BookResponse convertBookToResponse(Book book) {
+        return new BookResponse(book.getLibrary(), book.getLocation(), book.getRegistrationNumber(),
+                book.getTitle(), book.getAuthor(), book.getPublisher(),
+                book.getPublicationYear(), book.getCallNumber());
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -12,7 +12,7 @@ spring:
     generate-ddl: true
     show-sql: true
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
 
 jwt:
   secret: aiQoVnMwIDHv7+PfR8LE9gSk1hjJfFiFZKj+szimCno=

--- a/src/test/java/com/yunbok/searchapi/v1/authentication/service/AuthenticationServiceTest.java
+++ b/src/test/java/com/yunbok/searchapi/v1/authentication/service/AuthenticationServiceTest.java
@@ -43,9 +43,6 @@ public class AuthenticationServiceTest {
     @InjectMocks
     private AuthenticationService authenticationService;
 
-    @InjectMocks
-    private AuthenticationService authenticationService;
-
     @BeforeAll
     public void setup() {
         mockStatic(ApiKeyUtil.class);
@@ -66,14 +63,8 @@ public class AuthenticationServiceTest {
         ApiKeyResponse response = authenticationService.getApiKey(request);
         verify(apiKeyRepository).save(refEq(ApiKey.save(user, apiKeyGenerator.getHashedApiKey(apiKey))));
 
-        when(userRepository.findByAccountAndPassword(account, password)).thenReturn(user);
+        when(userRepository.findByAccountAndPassword(account, password)).thenReturn(Optional.of(user));
         when(ApiKeyUtil.generateApiKey()).thenReturn(apiKey);
-
-        ApiKeyRequest request = ApiKeyRequest.requestOf(account, password);
-
-        // when
-        ApiKeyResponse response = authenticationService.getApiKey(request);
-        verify(apiKeyRepository).save(refEq(ApiKey.save(user, ApiKeyUtil.getHashedApiKey(apiKey))));
 
         // then
         assertEquals(apiKey, response.getApiKey());

--- a/src/test/java/com/yunbok/searchapi/v1/search/parse/BookDataReader.java
+++ b/src/test/java/com/yunbok/searchapi/v1/search/parse/BookDataReader.java
@@ -1,0 +1,28 @@
+package com.yunbok.searchapi.v1.search.parse;
+
+import com.yunbok.searchapi.v1.search.entity.Book;
+import com.yunbok.searchapi.v1.search.repository.BookRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.List;
+
+@SpringBootTest
+@TestPropertySource(properties = {"spring.config.location = classpath:application-local.yml"})
+public class BookDataReader {
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    /**
+     * 1회성 코드
+     * 검색 api에 활용하기 위한 데이터를 파싱하여 저장한다.
+     */
+    @Test
+    public void parseAndSaveBooks() {
+        List<Book> books = BookParser.parse();
+        bookRepository.saveAll(books);
+    }
+}

--- a/src/test/java/com/yunbok/searchapi/v1/search/parse/BookParser.java
+++ b/src/test/java/com/yunbok/searchapi/v1/search/parse/BookParser.java
@@ -1,0 +1,38 @@
+package com.yunbok.searchapi.v1.search.parse;
+
+import com.yunbok.searchapi.v1.search.entity.Book;
+
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+public class BookParser {
+
+    public static List<Book> parse() {
+        String csvFile = "/Users/iyunbog/book.csv";
+        String line = "";
+        String csvSplitBy = ",";
+        ArrayList<Book> books = new ArrayList<>();
+
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(csvFile), StandardCharsets.UTF_8))) {
+            br.readLine();
+
+            while ((line = br.readLine()) != null) {
+                String[] bookInfo = line.split(csvSplitBy);
+
+                Book book = new Book(bookInfo[0], bookInfo[1], bookInfo[2], bookInfo[3],
+                        bookInfo[4], bookInfo[5], bookInfo[6], bookInfo[7]);
+
+                books.add(book);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return books;
+    }
+}


### PR DESCRIPTION
- 데이터 검색 api 구현
  - jwt token 검증
  - 검색 데이터 파싱 후 저장 로직 구현 
     - 원래 네이버, 다음 검색 api를 활용하려 했는데, 한게가 있어서 공공데이터에서 csv 파일(도서관 도서 목록) 하나 구해서 활용하려 합니다 
     - csv 파일 파싱 후, DB에 저장하는 로직을 작성하였습니다~, 1회성 코드라 일단 테스트 쪽에 구현했습니다.
  - 제목 검색하는 api 구현

**테스트 코드는 빠른 시일내에 추가해놓도록 할게요 ㅎ**


- 검색 기능 TODO 
   - sort 기능 추가
   - pagination 추가
   - 검색 종류 추가

- 다음주는 기능 구현보다 DDD를 학습해서 적용해보려고 합니다